### PR TITLE
Refactor TALYS code

### DIFF
--- a/neucbot.py
+++ b/neucbot.py
@@ -5,13 +5,13 @@ import os
 sys.path.insert(0, './Scripts/')
 import re
 import subprocess
-import shutil
 import math
 
 from neucbot import alpha
 from neucbot import ensdf
 from neucbot import elements
 from neucbot import material
+from neucbot import talys
 from neucbot import utils
 
 class constants:
@@ -32,79 +32,34 @@ class constants:
 def isoDir(ele,A):
     return './Data/Isotopes/'+ele.capitalize()+'/'+ele.capitalize()+str(int(A))+'/'
 
-def runTALYS(e_a, ele, A):
-    iso = str(ele)+str(int(A))
-    inpdir = isoDir(ele,A) + 'TalysInputs/'
-    outdir = isoDir(ele,A) + 'TalysOut/'
-    nspecdir= isoDir(ele,A) + 'NSpectra/'
-    if not os.path.exists(inpdir):
-        os.makedirs(inpdir)
-    if not os.path.exists(outdir):
-        os.makedirs(outdir)
-    if not os.path.exists(nspecdir):
-        os.makedirs(nspecdir)
-
-#    command = "\nprojectile a\nejectiles p n g\nelement "+ele+"\nmass "+str(int(A))+"\nenergy "+str(e_a)+"\npreequilibrium y\ngiantresonance y\nmultipreeq y\noutspectra y\noutlevels y\noutgamdis y\nfilespectrum n\nelwidth 0.2\n"
-    command = "\nprojectile a\nejectiles p n g\nelement "+ele+"\nmass "+str(int(A))+"\nenergy "+str(e_a)+"\npreequilibrium y\ngiantresonance y\nmultipreeq y\noutspectra y\noutlevels y\noutgamdis y\nfilespectrum n\nelwidth 0.2"
-
-    inp_fname = inpdir+"inputE"+str(e_a)
-    inp_f = open(inp_fname,'w')
-    inp_f.write(command)
-    inp_f.close()
-    out_fname = outdir+"outputE"+str(e_a)
-
-    bashcmd = 'talys < '+inp_fname+' > '+out_fname
-    print('Running TALYS:\t ', bashcmd, file = constants.ofile)
-    runscript_fname = "./runscript_temp.sh"
-    runscript_f = open(runscript_fname,"w")
-    runscript_f.write("#!/usr/bin/bash\n\n"+bashcmd)
-    runscript_f.close()
-    process = subprocess.call(bashcmd,shell=True)
-    # Move the output neutron spectrum to the appropriate directory
-    ls = os.listdir("./")
-
-    moved_file = False
-    for f in ls:
-        if "nspec" in f:
-            if os.path.exists(nspecdir+f):
-                os.remove(nspecdir+f)
-            fname = nspecdir+'nspec{0:0>7.3f}.tot'.format(e_a)
-            shutil.move(f, fname)
-            moved_file = True
-    # If no neutron spectrum file is found, make a blank one
-    if not moved_file:
-        fname = nspecdir+'nspec{0:0>7.3f}.tot'.format(e_a)
-        blank_f = open(fname,'w')
-        blank_f.write("EMPTY")
-        blank_f.close()
-
 def getIsotopeDifferentialNSpec(e_a, ele, A):
+    talys_runner = talys.Runner(ele, A)
+    rounded_alpha_energy = int(100 * e_a)/100.
+
     target = ele+str(int(A))
-    path = isoDir(ele,A) + 'NSpectra/'
-    if not os.path.exists(path):
-        os.makedirs(path)
-    fname = path+'nspec{0:0>7.3f}.tot'.format(int(100*e_a)/100.)
-    outpath = isoDir(ele,A) + 'TalysOut'
+    output_dir = talys_runner.output_dir
+
     if constants.force_recalculation:
-        print('Forcibily running TALYS for', int(100*e_a)/100., 'alpha on', target, file = constants.ofile)
-        print('Outpath', outpath, file = constants.ofile)
-        runTALYS(int(100*e_a)/100.,ele,A)
+        print('Forcibily running TALYS for', rounded_alpha_energy, 'alpha on', target, file = constants.ofile)
+        print('Outpath', output_dir, file = constants.ofile)
+        talys_runner.run(rounded_alpha_energy)
 
     # If the file does not exist, run TALYS
+    fname = talys_runner.spectra_file(rounded_alpha_energy)
     if not os.path.exists(fname):
         if constants.run_talys:
             while not os.path.exists(fname):
-                print('Running TALYS for', int(100*e_a)/100., 'alpha on', target, file = constants.ofile)
-                print('Outpath', outpath, file = constants.ofile)
-                runTALYS(int(100*e_a)/100.,ele,A)
-                ls = os.listdir(outpath)
+                print('Running TALYS for', rounded_alpha_energy, 'alpha on', target, file = constants.ofile)
+                print('Outpath', output_dir, file = constants.ofile)
+                talys_runner.run(rounded_alpha_energy)
+                ls = os.listdir(output_dir)
         else:
             print("Warning, no (alpha,n) data found for E_a =", e_a,"MeV on target", target,"...skipping. Consider running with the -d or -t options", file = constants.ofile)
             return {}
 
     # Load the file
     # If no output was produced, skip this energy
-    if not os.path.exists(outpath):
+    if not os.path.exists(output_dir):
         return {}
 
     f = open(fname)

--- a/neucbot/talys.py
+++ b/neucbot/talys.py
@@ -1,0 +1,89 @@
+import glob
+import os
+import subprocess
+
+from string import Template
+
+ISOTOPES_DIR = "./Data/Isotopes"
+
+command_template = Template(
+    """
+projectile a
+ejectiles p n g
+element $element
+mass $mass_number
+energy $alpha_energy
+preequilibrium y
+giantresonance y
+multipreeq y
+outspectra y
+outlevels y
+outgamdis y
+filespectrum n
+elwidth 0.2
+"""
+)
+
+
+class Runner:
+    def __init__(self, element, mass_number):
+        iso = element + str(mass_number)
+        base_path = os.path.join(ISOTOPES_DIR, element, iso)
+
+        self.element = element
+        self.mass_number = mass_number
+        self.input_dir = os.path.join(base_path, "TalysInputs")
+        self.output_dir = os.path.join(base_path, "TalysOut")
+        self.spectra_dir = os.path.join(base_path, "NSpectra")
+
+        os.makedirs(self.input_dir, exist_ok=True)
+        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(self.spectra_dir, exist_ok=True)
+
+    def run(self, alpha_energy):
+        input_file_path = self.input_file(alpha_energy)
+        output_file_path = self.output_file(alpha_energy)
+
+        # Write talys input file
+        input_file = open(input_file_path, "w")
+        input_file.write(
+            command_template.substitute(
+                element=self.element,
+                mass_number=self.mass_number,
+                alpha_energy=alpha_energy,
+            )
+        )
+        input_file.close()
+
+        talys_command = f"talys < {input_file_path} > {output_file_path}"
+
+        # Run talys command to generate files
+        result = subprocess.call(talys_command, shell=True)
+
+        # Check result for successful exit
+        if result == 0:
+            print(f"Successfully ran command: {talys_command}")
+        else:
+            raise RuntimeError(f"Failed TALYS command: {talys_command}")
+
+        # Move TALYS files to expected output
+        generated_nspec_files = glob.glob(".*nspec.*")
+        nspec_file_path = self.spectra_file(alpha_energy)
+
+        if generated_nspec_files and len(generated_nspec_files) == 1:
+            os.replace(generated_nspec_files[0], nspec_file_path)
+        else:
+            nspec_file = open(nspec_file_path, "w")
+            nspec_file.write("EMPTY")
+            nspec_file.close()
+
+    def input_file(self, alpha_energy):
+        return os.path.join(self.input_dir, f"inputE{alpha_energy}")
+
+    def output_file(self, alpha_energy):
+        return os.path.join(self.output_dir, f"outputE{alpha_energy}")
+
+    def spectra_file(self, alpha_energy):
+        return os.path.join(
+            self.spectra_dir, "nspec{0:0>7.3f}.tot".format(alpha_energy)
+        )

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -86,4 +86,45 @@ else
   rm tmp-acrylic-bi212-alphalist.txt
 fi
 
+############################
+# TALYS Recalculation Test #
+############################
+
+echo
+echo "Running test with TALYS..."
+echo "--------------------------"
+echo "Materials/Acrylic.dat"
+echo "AlphaLists/Bi212Alphas.dat"
+echo
+
+echo "Removing subset of TALYS files..."
+rm Data/Isotopes/C/C12/TalysOut/outputE0.0*
+rm Data/Isotopes/C/C12/NSpectra/nspec000.0*
+
+echo "Running neucbot.py with -t enabled..."
+python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2  -t
+
+# Since ./neucbot.py prints TALYS information when it is enabled, the output file won't be exactly the same.
+# The run above downloads the missing files from TALYS and this subsequent run
+# verifies the output.
+echo "Running neucbot.py to verify successful TALYS download..."
+python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt
+diff tmp-acrylic-bi212-alphalist.txt tests/integration_tests/acrylic-bi212-alphalist.txt
+
+if [ $? -eq 1 ]; then
+  echo
+  echo "Test failed" >&2
+  echo
+  rm tmp-acrylic-bi212-alphalist.txt
+
+  exit 1
+else
+  echo
+  echo "Test passed"
+  echo
+  rm tmp-acrylic-bi212-alphalist.txt
+fi
+
+
 echo "All tests passed, no regressions introduced."
+

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -90,40 +90,40 @@ fi
 # TALYS Recalculation Test #
 ############################
 
-echo
-echo "Running test with TALYS..."
-echo "--------------------------"
-echo "Materials/Acrylic.dat"
-echo "AlphaLists/Bi212Alphas.dat"
-echo
+# echo
+# echo "Running test with TALYS..."
+# echo "--------------------------"
+# echo "Materials/Acrylic.dat"
+# echo "AlphaLists/Bi212Alphas.dat"
+# echo
 
-echo "Removing subset of TALYS files..."
-rm Data/Isotopes/C/C12/TalysOut/outputE0.0*
-rm Data/Isotopes/C/C12/NSpectra/nspec000.0*
+# echo "Removing subset of TALYS files..."
+# rm Data/Isotopes/C/C12/TalysOut/outputE0.0*
+# rm Data/Isotopes/C/C12/NSpectra/nspec000.0*
 
-echo "Running neucbot.py with -t enabled..."
-python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2  -t
+# echo "Running neucbot.py with -t enabled..."
+# python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2  -t
 
-# Since ./neucbot.py prints TALYS information when it is enabled, the output file won't be exactly the same.
-# The run above downloads the missing files from TALYS and this subsequent run
-# verifies the output.
-echo "Running neucbot.py to verify successful TALYS download..."
-python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt
-diff tmp-acrylic-bi212-alphalist.txt tests/integration_tests/acrylic-bi212-alphalist.txt
+# # Since ./neucbot.py prints TALYS information when it is enabled, the output file won't be exactly the same.
+# # The run above downloads the missing files from TALYS and this subsequent run
+# # verifies the output.
+# echo "Running neucbot.py to verify successful TALYS download..."
+# python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt
+# diff tmp-acrylic-bi212-alphalist.txt tests/integration_tests/acrylic-bi212-alphalist.txt
 
-if [ $? -eq 1 ]; then
-  echo
-  echo "Test failed" >&2
-  echo
-  rm tmp-acrylic-bi212-alphalist.txt
+# if [ $? -eq 1 ]; then
+#   echo
+#   echo "Test failed" >&2
+#   echo
+#   rm tmp-acrylic-bi212-alphalist.txt
 
-  exit 1
-else
-  echo
-  echo "Test passed"
-  echo
-  rm tmp-acrylic-bi212-alphalist.txt
-fi
+#   exit 1
+# else
+#   echo
+#   echo "Test passed"
+#   echo
+#   rm tmp-acrylic-bi212-alphalist.txt
+# fi
 
 
 echo "All tests passed, no regressions introduced."

--- a/tests/test_talys.py
+++ b/tests/test_talys.py
@@ -1,0 +1,117 @@
+import pytest
+
+from unittest import TestCase
+from unittest.mock import call, mock_open, patch
+
+from neucbot.talys import command_template, Runner
+
+
+@patch("os.makedirs")
+class TestRunner(TestCase):
+
+    @patch("os.replace")
+    @patch("glob.glob", return_value=["nspec001.000.tot"])
+    @patch("subprocess.call", return_value=0)
+    def test_run_generated_nspec_files(
+        self, mocked_subprocess_call, mocked_glob, mocked_replace, mocked_makedirs
+    ):
+        mocked_open = mock_open()
+        with patch("builtins.open", mocked_open):
+            runner = Runner("C", 12)
+            runner.run(1.00)
+
+            mocked_makedirs.assert_has_calls(
+                [
+                    call("./Data/Isotopes/C/C12/TalysInputs", exist_ok=True),
+                    call("./Data/Isotopes/C/C12/TalysOut", exist_ok=True),
+                    call("./Data/Isotopes/C/C12/NSpectra", exist_ok=True),
+                ]
+            )
+
+            mocked_open.assert_has_calls(
+                [
+                    call("./Data/Isotopes/C/C12/TalysInputs/inputE1.0", "w"),
+                    call().write(
+                        command_template.substitute(
+                            element="C", mass_number=12, alpha_energy=1.00
+                        )
+                    ),
+                    call().close(),
+                ]
+            )
+
+            mocked_subprocess_call.assert_has_calls(
+                [
+                    call(
+                        "talys < ./Data/Isotopes/C/C12/TalysInputs/inputE1.0 > ./Data/Isotopes/C/C12/TalysOut/outputE1.0",
+                        shell=True,
+                    ),
+                ]
+            )
+
+            mocked_glob.assert_has_calls([call(".*nspec.*")])
+
+            mocked_replace.assert_has_calls(
+                [
+                    call(
+                        "nspec001.000.tot",
+                        "./Data/Isotopes/C/C12/NSpectra/nspec001.000.tot",
+                    )
+                ]
+            )
+
+    @patch("glob.glob")
+    @patch("subprocess.call", return_value=0)
+    def test_run_empty_nspec_files(
+        self, mocked_subprocess_call, mocked_glob, mocked_makedirs
+    ):
+        mocked_open = mock_open()
+        with patch("builtins.open", mocked_open):
+            runner = Runner("C", 12)
+            runner.run(1.00)
+
+            mocked_makedirs.assert_has_calls(
+                [
+                    call("./Data/Isotopes/C/C12/TalysInputs", exist_ok=True),
+                    call("./Data/Isotopes/C/C12/TalysOut", exist_ok=True),
+                    call("./Data/Isotopes/C/C12/NSpectra", exist_ok=True),
+                ]
+            )
+
+            mocked_open.assert_has_calls(
+                [
+                    call("./Data/Isotopes/C/C12/TalysInputs/inputE1.0", "w"),
+                    call().write(
+                        command_template.substitute(
+                            element="C", mass_number=12, alpha_energy=1.00
+                        )
+                    ),
+                    call().close(),
+                    call("./Data/Isotopes/C/C12/NSpectra/nspec001.000.tot", "w"),
+                    call().write("EMPTY"),
+                    call().close(),
+                ]
+            )
+
+            mocked_subprocess_call.assert_has_calls(
+                [
+                    call(
+                        "talys < ./Data/Isotopes/C/C12/TalysInputs/inputE1.0 > ./Data/Isotopes/C/C12/TalysOut/outputE1.0",
+                        shell=True,
+                    ),
+                ]
+            )
+
+            mocked_glob.assert_has_calls([call(".*nspec.*")])
+
+    @patch("glob.glob")
+    @patch("subprocess.call", return_value=1)
+    def test_run_failed_talys(
+        self, mocked_subprocess_call, mocked_glob, mocked_makedirs
+    ):
+        mocked_open = mock_open()
+        with patch("builtins.open", mocked_open):
+            runner = Runner("C", 12)
+
+            with self.assertRaisesRegex(RuntimeError, r"Failed TALYS command:"):
+                runner.run(1.00)


### PR DESCRIPTION
This commit moves TALYS related code to neucbot/talys.py and makes a few improvements including:

- Removing the creation of the unused runscript_f file
- Using os.replace to replace existing nspec files

An integration test has been added to verify TALYS functionality, but it is currently commented out. In a subsequent PR, I'll work on getting `talys` installed in the Github Action so that the test can be run there.