### PR TITLE
Add NeucbotRunner class

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,4 +30,4 @@ jobs:
         run: ./tests/integration_tests.sh
 
       - name: Run linter
-        run: python -m black neucbot/ tests/ --check
+        run: python -m black **/*.py --check

--- a/neucbot.py
+++ b/neucbot.py
@@ -1,78 +1,58 @@
 #!/usr/bin/python3
-
-import sys
-import os
-sys.path.insert(0, './Scripts/')
-import subprocess
-
 from argparse import ArgumentParser
-from tqdm import tqdm
 
 from neucbot.alpha import AlphaList, ChainAlphaList
+from neucbot import config
 from neucbot import material
-from neucbot import talys
-from neucbot import utils
+from neucbot.runner import NeucbotRunner
 
-class constants:
-    run_talys  = False
-    force_recalculation = False
-    ofile = sys.stdout
-
-def run_alpha(alpha_list, mat_comp, e_alpha_step=0.01):
-    spec_tot = {}
-    xsects = {}
-    total_xsect = 0
-    for [e_a, intensity] in tqdm(alpha_list.condense(e_alpha_step)):
-        stopping_power = mat_comp.stopping_power(e_a)
-
-        for mat in mat_comp.materials:
-            mat_term = mat.material_term()
-            # Get alpha n spectrum for this alpha and this target
-            spec = mat.differential_n_spec(e_a, constants.run_talys, constants.force_recalculation).rebin()
-
-            # Add this spectrum to the total spectrum
-            delta_ea = e_a if e_alpha_step > e_a else e_alpha_step
-            prefactors = (intensity/100.)*mat_term*delta_ea/stopping_power
-            xsect = prefactors * mat.cross_section(e_a)
-            total_xsect += xsect
-
-            xsects[mat.name()] = xsects.get(mat.name(), 0) + xsect
-            for e in spec.keys():
-                spec_tot[e] = spec_tot.get(e, 0) + prefactors * spec.get(e)
-
-    print('',file = constants.ofile)
-    print('# Total neutron yield = ', utils.format_float(total_xsect), ' n/decay', file = constants.ofile)
-
-    for x in sorted(xsects):
-        print('\t', x, utils.format_float(xsects[x]), file = constants.ofile)
-
-    print('# Integral of spectrum = ', utils.format_float(utils.Histogram(spec_tot).integrate()), " n/decay", file = constants.ofile)
-    for e in sorted(spec_tot):
-        print(e, utils.format_float(spec_tot[e]), file = constants.ofile)
 
 def main():
-    alpha_list = []
-    mat_comp = []
-
     parser = ArgumentParser(
-            prog="neucbot",
-            description="NeuCBOT is a tool for calculating (alpha,n) yields and neutron energy spectra for arbitrary materials under alpha exposure for arbitrary lists of alpha energies or in the presence of alpha-emitting contaminants."
-            )
+        prog="neucbot",
+        description="NeuCBOT is a tool for calculating (alpha,n) yields and neutron energy spectra for arbitrary materials under alpha exposure for arbitrary lists of alpha energies or in the presence of alpha-emitting contaminants.",
+    )
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("-l", "--alpha-list", help="Alpha list file name")
     group.add_argument("-c", "--chain-list", help="Decay chain file name")
 
-    parser.add_argument("-m", "--material", required=True, help="Material composition file name")
-    parser.add_argument("-s", "--step-size", type=float, default=0.01, help="Step size for integrating alphas (in MeV)")
-    parser.add_argument("-t", "--talys", type=bool, help="Run TALYS for reactions not found in ./Data")
-    parser.add_argument("-d", "--download", choices=["v1", "v2"], help="Download isotopic data for isotopes missing from database (options: %(choices)s)")
+    parser.add_argument(
+        "-m", "--material", required=True, help="Material composition file name"
+    )
+    parser.add_argument(
+        "-s",
+        "--step-size",
+        type=float,
+        default=0.01,
+        help="Step size for integrating alphas (in MeV)",
+    )
+    parser.add_argument(
+        "-t", "--talys", type=bool, help="Run TALYS for reactions not found in ./Data"
+    )
+    parser.add_argument(
+        "-d",
+        "--download",
+        choices=["v1", "v2"],
+        help="Download isotopic data for isotopes missing from database (options: %(choices)s)",
+    )
     parser.add_argument("-o", "--output", help="Output file name")
     parser.add_argument("--print-alphas", action="store_true", help="Print alpha list")
-    parser.add_argument("--print-alphas-only", action="store_true", help="Print alpha list without running calculations")
-    parser.add_argument("--force-recalculation", action="store_true", help="Force recalculation of TALYS outputs")
+    parser.add_argument(
+        "--print-alphas-only",
+        action="store_true",
+        help="Print alpha list without running calculations",
+    )
+    parser.add_argument(
+        "--force-recalculation",
+        action="store_true",
+        help="Force recalculation of TALYS outputs",
+    )
 
     args = parser.parse_args()
+
+    cfg = config.Config(vars(args))
+    runner = NeucbotRunner(cfg)
 
     if args.alpha_list:
         alpha_list = AlphaList.from_filepath(args.alpha_list)
@@ -83,35 +63,17 @@ def main():
 
     material_composition = material.Composition.from_file(args.material)
 
-    if args.talys:
-        constants.run_talys = True
-
     if args.print_alphas or args.print_alphas_only:
-        print('Alpha List: ', file = sys.stdout)
-        print(max(alpha_list.alphas), file = sys.stdout)
-        for [alpha, intensity] in alpha_list.condense(args.step_size):
-            print(alpha,'&', intensity,'\\\\', file = sys.stdout)
-
-    if args.print_alphas_only:
-        return
+        print("Alpha List: ")
+        print(alpha_list.max_alpha())
+        for [alpha, intensity] in alpha_list.condense(step_size):
+            print(alpha, "&", intensity, "\\\\")
 
     if args.download:
-        for mat in material_composition.materials:
-            if not (os.listdir(mat.talys_output_dir()) and os.listdir(mat.talys_spectra_dir())):
-                print(f"Downloading (datset {args.download}) data for {mat.element.symbol}", file = sys.stdout)
-                bashcmd = f"./Scripts/download_element_{args.download}.sh {mat.element.symbol}"
-                process = subprocess.call(bashcmd,shell=True)
+        material_composition.download_data(args.download)
 
-    if args.force_recalculation:
-        constants.force_recalculation = True
+    runner.run(alpha_list, material_composition, args.step_size)
 
-    if args.output:
-        ofile = str(args.output)
-        print('Printing output to',ofile, file = sys.stdout)
-        constants.ofile = open(ofile,'w')
 
-    print('Running alphas:', file = sys.stdout)
-    run_alpha(alpha_list, material_composition, args.step_size)
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/neucbot/alpha.py
+++ b/neucbot/alpha.py
@@ -118,6 +118,9 @@ class AlphaList:
 
         return condensed_alphas
 
+    def max_alpha(self):
+        return max(self.alphas)
+
 
 class ChainAlphaList(AlphaList):
     CHAIN_LIST_FILE_PATTERN = re.compile(

--- a/neucbot/config.py
+++ b/neucbot/config.py
@@ -1,0 +1,11 @@
+import sys
+
+
+class Config:
+    def __init__(self, args):
+        self.talys = args.get("talys")
+        self.download = args.get("download")
+        self.force_recalculation = args.get("force_recalculation")
+        self.output = (
+            open(args.get("output"), "w") if args.get("output") else sys.stdout
+        )

--- a/neucbot/material.py
+++ b/neucbot/material.py
@@ -1,5 +1,6 @@
 import os
 import re
+import subprocess
 
 from bisect import bisect
 
@@ -232,3 +233,17 @@ class Composition:
             total_stopping_power += element_stop_power * fraction
 
         return total_stopping_power
+
+    def download_data(self, version):
+        for material in self.materials:
+            if not (
+                os.listdir(material.talys_output_dir())
+                and os.listdir(material.talys_spectra_dir())
+            ):
+                print(
+                    f"Downloading (datset {version}) data for {material.element.symbol}"
+                )
+                bashcmd = (
+                    f"./Scripts/download_element_{version}.sh {material.element.symbol}"
+                )
+                process = subprocess.call(bashcmd, shell=True)

--- a/neucbot/runner.py
+++ b/neucbot/runner.py
@@ -1,0 +1,73 @@
+from tqdm import tqdm
+from neucbot import alpha
+from neucbot import config
+from neucbot import talys
+from neucbot import utils
+
+ALPHA_STEP = 0.01  # MeV
+
+
+class NeucbotRunner:
+    def __init__(self, cfg):
+        self.config = cfg
+
+    def run(self, alpha_list, material_composition, step_size=ALPHA_STEP):
+        run_talys = self.config.talys
+        force_recalc = self.config.force_recalculation
+        print("Running alphas:")
+
+        spec_totals = {}
+        cross_sections = {}
+        total_cross_section = 0
+
+        for [energy, intensity] in tqdm(alpha_list.condense(step_size)):
+            stopping_power = material_composition.stopping_power(energy)
+
+            for material in material_composition.materials:
+                mat_term = material.material_term()
+                mat_name = material.name()
+
+                # Get alpha n spectrum for this alpha and this target
+                spec = material.differential_n_spec(
+                    energy, run_talys, force_recalc
+                ).rebin()
+
+                # Add this spectrum to the total spectrum
+                delta_ea = energy if step_size > energy else step_size
+                prefactors = (intensity / 100.0) * mat_term * delta_ea / stopping_power
+                xsect = prefactors * material.cross_section(energy)
+                total_cross_section += xsect
+
+                cross_sections[mat_name] = cross_sections.get(mat_name, 0) + xsect
+
+                for e in spec.keys():
+                    spec_totals[e] = spec_totals.get(e, 0) + prefactors * spec.get(e)
+
+        self.print_outputs(total_cross_section, cross_sections, spec_totals)
+
+        return {
+            "total_cross_section": total_cross_section,
+            "cross_sections": cross_sections,
+            "spectra_totals": spec_totals,
+        }
+
+    def print_outputs(self, total_cross_section, cross_sections, spectra_totals):
+        output_file = self.config.output
+
+        rounded_total = utils.format_float(total_cross_section)
+        rounded_integral = utils.format_float(
+            utils.Histogram(spectra_totals).integrate()
+        )
+
+        print("", file=output_file)
+        print("# Total neutron yield = ", rounded_total, " n/decay", file=output_file)
+
+        for x in sorted(cross_sections):
+            print("\t", x, utils.format_float(cross_sections[x]), file=output_file)
+
+        print(
+            "# Integral of spectrum = ", rounded_integral, " n/decay", file=output_file
+        )
+
+        for e in sorted(spectra_totals):
+            print(e, utils.format_float(spectra_totals[e]), file=output_file)

--- a/parseENSDF.py
+++ b/parseENSDF.py
@@ -2,15 +2,17 @@
 import sys
 from neucbot import alpha
 
+
 def main(argv):
-    if(len(argv) != 3):
-        print('Usage: ./parseENSDF [element] [A]')
+    if len(argv) != 3:
+        print("Usage: ./parseENSDF [element] [A]")
         return
 
     ele = argv[1]
     A = int(argv[2])
 
     alpha.AlphaList(ele, A).write()
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/tests/test_alpha.py
+++ b/tests/test_alpha.py
@@ -149,6 +149,11 @@ class TestAlphaList(TestCase):
             ],
         )
 
+    def test_max_alpha(self):
+        alpha_list = AlphaList.from_filepath("AlphaLists/Bi212Alphas.dat")
+        alpha_list.load_or_fetch()
+        assert alpha_list.max_alpha() == [6.08988, 27.12]
+
     @patch.object(AlphaList, "write")
     @patch("os.path.isfile")
     def test_load_or_fetch_raises_on_failed_write(self, mocked_isfile, mocked_write):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -245,6 +245,49 @@ class TestComposition(TestCase):
         # 25% stopping power of O = 0.25 * 462.8758
         assert comp.stopping_power(11.0) == 701.5617
 
+    @patch("subprocess.call")
+    @patch("os.listdir", return_value=["data"])
+    def test_download_data_all_data_present(self, mocked_listdir, mocked_call):
+        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
+
+        comp.download_data("v2")
+
+        mocked_listdir.assert_has_calls(
+            [
+                call("./Data/Isotopes/C/C12/TalysOut"),
+                call("./Data/Isotopes/C/C12/NSpectra"),
+                call("./Data/Isotopes/O/O16/TalysOut"),
+                call("./Data/Isotopes/O/O16/NSpectra"),
+                call("./Data/Isotopes/H/H1/TalysOut"),
+                call("./Data/Isotopes/H/H1/NSpectra"),
+            ]
+        )
+
+        mocked_call.assert_has_calls([])
+
+    @patch("subprocess.call")
+    @patch("os.listdir", return_value=[])
+    def test_download_data_missing_data(self, mocked_listdir, mocked_call):
+        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
+
+        comp.download_data("v2")
+
+        mocked_listdir.assert_has_calls(
+            [
+                call("./Data/Isotopes/C/C12/TalysOut"),
+                call("./Data/Isotopes/O/O16/TalysOut"),
+                call("./Data/Isotopes/H/H1/TalysOut"),
+            ]
+        )
+
+        mocked_call.assert_has_calls(
+            [
+                call("./Scripts/download_element_v2.sh C", shell=True),
+                call("./Scripts/download_element_v2.sh O", shell=True),
+                call("./Scripts/download_element_v2.sh H", shell=True),
+            ]
+        )
+
 
 class TestStoppingPowerList(TestCase):
     def test_load_file(self):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -5,11 +5,19 @@ from unittest.mock import call, patch
 
 import numpy
 
-from neucbot import alpha, config, material, runner
+from neucbot import alpha, config, material, runner, utils
 
 
 class TestNeucbotRunner(TestCase):
-    def test_run(self):
+    @patch.object(material.Isotope, "cross_section", return_value=1e-27)
+    @patch.object(utils.Histogram, "rebin", return_value=utils.Histogram({1000: 1}))
+    @patch.object(
+        material.Isotope, "differential_n_spec", return_value=utils.Histogram()
+    )
+    @patch.object(material.Composition, "stopping_power", return_value=100)
+    def test_run(
+        self, mocked_stop_power, mocked_diff_n_spec, mocked_rebin, mocked_cross_sect
+    ):
         cfg = config.Config({})
         neucbot = runner.NeucbotRunner(cfg)
 
@@ -20,12 +28,12 @@ class TestNeucbotRunner(TestCase):
 
         expected = {
             "cross_sections": {
-                "C12": numpy.float64(0.0),
-                "H1": numpy.float64(0.0),
-                "O16": numpy.float64(0.0),
+                "C12": pytest.approx(1.517498e-06),
+                "H1": pytest.approx(9.104992e-06),
+                "O16": pytest.approx(5.690620e-07),
             },
-            "spectra_totals": {},
-            "total_cross_section": numpy.float64(0.0),
+            "spectra_totals": {1000: pytest.approx(1.119155e22)},
+            "total_cross_section": pytest.approx(1.119155e-05),
         }
 
         assert neucbot.run(alpha_list, comp) == expected

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,31 @@
+import pytest
+
+from unittest import TestCase
+from unittest.mock import call, patch
+
+import numpy
+
+from neucbot import alpha, config, material, runner
+
+
+class TestNeucbotRunner(TestCase):
+    def test_run(self):
+        cfg = config.Config({})
+        neucbot = runner.NeucbotRunner(cfg)
+
+        alpha_list = alpha.AlphaList.from_filepath("AlphaLists/Bi212Alphas.dat")
+        alpha_list.load_or_fetch()
+
+        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
+
+        expected = {
+            "cross_sections": {
+                "C12": numpy.float64(0.0),
+                "H1": numpy.float64(0.0),
+                "O16": numpy.float64(0.0),
+            },
+            "spectra_totals": {},
+            "total_cross_section": numpy.float64(0.0),
+        }
+
+        assert neucbot.run(alpha_list, comp) == expected


### PR DESCRIPTION
This PR migrates the run function from neucbot.py into a new NeucbotRunner class. It also moves most of the remaining functionality from neucbot.py into the appropriate classes under the neucbot/ package.

In addition, all files in neucbot have been formatted (with `black`), and that change is reflected in the Github workflow.

Next up will be some easier performance improvements and getting this spun up in a web server (in a separate repo).