### PR TITLE
Disable TALYS if command not present

### DIFF
--- a/neucbot.py
+++ b/neucbot.py
@@ -52,6 +52,7 @@ def main():
     args = parser.parse_args()
 
     cfg = config.Config(vars(args))
+    cfg.validate()
     runner = NeucbotRunner(cfg)
 
     if args.alpha_list:

--- a/neucbot/config.py
+++ b/neucbot/config.py
@@ -1,4 +1,5 @@
 import sys
+import shutil
 
 
 class Config:
@@ -9,3 +10,16 @@ class Config:
         self.output = (
             open(args.get("output"), "w") if args.get("output") else sys.stdout
         )
+
+    def validate(self):
+        # Return True if TALYS is not being run
+        if not self.talys:
+            return
+
+        # If TALYS is being run, verify that the talys command is present
+        if shutil.which("talys"):
+            return
+        else:
+            raise RuntimeError(
+                "Attempting to run TALYS when talys command is not available"
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+import pytest
+import logging
+
+from unittest import TestCase
+from unittest.mock import call, patch
+
+from neucbot import config
+
+
+class TestConfig(TestCase):
+    @patch("shutil.which", return_value=True)
+    def test_validate_no_talys_configured(self, mock_which):
+        config.Config({"talys": False}).validate()
+        mock_which.assert_has_calls([])
+
+    @patch("shutil.which", return_value=True)
+    def test_validate_talys_configured_command_present(self, mock_which):
+        config.Config({"talys": True}).validate()
+        mock_which.assert_has_calls([call("talys")])
+
+    @patch("shutil.which", return_value=False)
+    def test_validate_talys_configured_command_not_present(self, mock_which):
+        with self.assertRaisesRegex(RuntimeError, r"talys command is not available"):
+            config.Config({"talys": True}).validate()
+            mock_which.assert_has_calls([call("talys")])


### PR DESCRIPTION
This commit disables the `--talys` flag in neucBOT configuration if the `talys` command is not available. Currently, the program will fail, but this allows for a more graceful exit.