### PR TITLE
Add .from_json methods to AlphaList and Composition classes

### DIFF
--- a/neucbot/alpha.py
+++ b/neucbot/alpha.py
@@ -31,6 +31,26 @@ class AlphaList:
         else:
             raise RuntimeError(f"Invalid file path for alphalist {file_path}")
 
+    # This method will be used from the neucbot web client, where alpha lists are
+    # constructed differently than they are from the neucbot CLI. Alphas will be
+    # provided in the request body and can be set directly on the AlphaList object
+    @classmethod
+    def from_json(cls, request_json):
+        alpha_list = cls(request_json["element"], request_json["isotope"])
+        alphas = request_json["alphas"]
+
+        alpha_list.set_alphas(
+            [[alpha, intensity] for alpha, intensity in alphas.items()]
+        )
+
+        return alpha_list
+
+    def get_alphas(self):
+        return self.alphas
+
+    def set_alphas(self, alphas):
+        self.alphas = alphas
+
     def load_or_fetch(self):
         while not os.path.isfile(self.file_path):
             if self.fetch_attempts < 0:

--- a/neucbot/material.py
+++ b/neucbot/material.py
@@ -157,32 +157,25 @@ class Composition:
             if len(material) < 3:
                 continue
 
-            element = elements.Element(material[0])
-            mass_number = int(material[1])
-            fraction = float(material[2])
+            composition.add(
+                {
+                    "element": material[0],
+                    "mass_number": material[1],
+                    "fraction": material[2],
+                }
+            )
 
-            # If a single mass number isn't specified, use all isotopes
-            # along with their natural abundances
-            if mass_number == 0:
-                for isotope in element.isotopes():
-                    composition.add(
-                        Isotope(
-                            element,
-                            isotope,
-                            fraction * element.abundance(isotope) / 100.0,
-                        )
-                    )
+        composition.normalize()
+        composition.populate_stopping_powers()
 
-            # Otherwise, if a single mass number is provided,
-            # use the fraction provided
-            else:
-                composition.add(
-                    Isotope(
-                        element,
-                        mass_number,
-                        fraction / 100.0,
-                    )
-                )
+        return composition
+
+    @classmethod
+    def from_json(cls, request_json):
+        composition = cls()
+
+        for material_element in request_json["elements"]:
+            composition.add(material_element)
 
         composition.normalize()
         composition.populate_stopping_powers()
@@ -220,8 +213,33 @@ class Composition:
     def empty(self):
         return len(self.materials) == 0
 
-    def add(self, material):
-        self.materials.append(material)
+    def add(self, material_element):
+        element = elements.Element(material_element["element"])
+        mass_number = int(material_element["mass_number"])
+        fraction = float(material_element["fraction"])
+
+        # If a single mass number isn't specified, use all isotopes
+        # along with their natural abundances
+        if mass_number == 0:
+            for isotope in element.isotopes():
+                self.materials.append(
+                    Isotope(
+                        element,
+                        isotope,
+                        fraction * element.abundance(isotope) / 100.0,
+                    )
+                )
+
+        # Otherwise, if a single mass number is provided,
+        # use the fraction provided
+        else:
+            self.materials.append(
+                Isotope(
+                    element,
+                    mass_number,
+                    fraction / 100.0,
+                )
+            )
 
     # Expects an alpha energy in units of MeV
     def stopping_power(self, e_alpha):

--- a/tests/test_alpha.py
+++ b/tests/test_alpha.py
@@ -104,6 +104,40 @@ class TestAlphaList(TestCase):
             ],
         )
 
+    def test_from_json(self):
+        request_json = {
+            "element": "Bi",
+            "isotope": 212,
+            "alphas": {
+                6.08988: 27.12,
+                6.05078: 69.91,
+                5.768: 1.7,
+                5.626: 0.157,
+                5.607: 1.13,
+                5.481: 0.013,
+                5.345: 0.001,
+                5.302: 0.00011,
+            },
+        }
+
+        alpha_list = AlphaList.from_json(request_json)
+
+        self.assertEqual(alpha_list.element, "Bi")
+        self.assertEqual(alpha_list.isotope, 212)
+        self.assertEqual(
+            alpha_list.alphas,
+            [
+                [6.08988, 27.12],
+                [6.05078, 69.91],
+                [5.768, 1.7],
+                [5.626, 0.157],
+                [5.607, 1.13],
+                [5.481, 0.013],
+                [5.345, 0.001],
+                [5.302, 0.00011],
+            ],
+        )
+
     @patch.object(AlphaList, "write")
     @patch("os.path.isfile")
     def test_load_or_fetch_success(self, mocked_isfile, mocked_write):

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -210,12 +210,44 @@ class TestComposition(TestCase):
         assert comp.fractions.get("H") == pytest.approx(0.25)
         assert comp.fractions.get("O") == pytest.approx(0.25)
 
+    def test_from_json(self):
+        request_json = {
+            "elements": [
+                {"element": "C", "mass_number": "12", "fraction": "33"},
+                {"element": "H", "mass_number": "1", "fraction": "33"},
+                {"element": "O", "mass_number": "16", "fraction": "34"},
+            ]
+        }
+
+        comp = material.Composition.from_json(request_json)
+
+        assert len(comp.materials) == 3
+        assert comp.fractions.get("C") == pytest.approx(0.33)
+        assert comp.fractions.get("H") == pytest.approx(0.33)
+        assert comp.fractions.get("O") == pytest.approx(0.34)
+
+    def test_from_json_no_isotopes_specified(self):
+        request_json = {
+            "elements": [
+                {"element": "C", "mass_number": "0", "fraction": "33"},
+                {"element": "H", "mass_number": "0", "fraction": "33"},
+                {"element": "O", "mass_number": "0", "fraction": "34"},
+            ]
+        }
+
+        comp = material.Composition.from_json(request_json)
+
+        assert len(comp.materials) == 7
+        assert comp.fractions.get("C") == pytest.approx(0.33)
+        assert comp.fractions.get("H") == pytest.approx(0.33)
+        assert comp.fractions.get("O") == pytest.approx(0.34)
+
     def test_normalize(self):
         comp = material.Composition()
 
-        comp.add(material.Isotope(elements.Element("C"), 12, 0.4))
-        comp.add(material.Isotope(elements.Element("H"), 12, 0.2))
-        comp.add(material.Isotope(elements.Element("O"), 12, 0.2))
+        comp.add({"element": "C", "mass_number": 12, "fraction": 0.4})
+        comp.add({"element": "H", "mass_number": 12, "fraction": 0.2})
+        comp.add({"element": "O", "mass_number": 12, "fraction": 0.2})
 
         comp.normalize()
 


### PR DESCRIPTION
These methods will be used from the neucbot web client for creating alpha list and material composition objects from request JSON.