### PR TITLE
Add option for JSON outputs

### DIFF
--- a/neucbot.py
+++ b/neucbot.py
@@ -49,9 +49,7 @@ def main():
         help="Force recalculation of TALYS outputs",
     )
     parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Return outputs as JSON object"
+        "--json", action="store_true", help="Return outputs as JSON object"
     )
 
     args = parser.parse_args()

--- a/neucbot.py
+++ b/neucbot.py
@@ -48,6 +48,11 @@ def main():
         action="store_true",
         help="Force recalculation of TALYS outputs",
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Return outputs as JSON object"
+    )
 
     args = parser.parse_args()
 

--- a/neucbot/config.py
+++ b/neucbot/config.py
@@ -10,6 +10,7 @@ class Config:
         self.output = (
             open(args.get("output"), "w") if args.get("output") else sys.stdout
         )
+        self.json = args.get("json")
 
     def validate(self):
         # Return True if TALYS is not being run

--- a/neucbot/runner.py
+++ b/neucbot/runner.py
@@ -51,11 +51,15 @@ class NeucbotRunner:
 
         outputs = {
             "total_neutron_yield": utils.format_float(total_cross_section),
-            "cross_sections": {el: utils.format_float(x) for el, x in cross_sections.items()},
+            "cross_sections": {
+                el: utils.format_float(x) for el, x in cross_sections.items()
+            },
             "spectrum_integral": utils.format_float(
                 utils.Histogram(spec_totals).integrate()
             ),
-            "spectra_totals": {e: utils.format_float(v) for e, v in spec_totals.items()},
+            "spectra_totals": {
+                e: utils.format_float(v) for e, v in spec_totals.items()
+            },
         }
 
         if self.config.json:
@@ -68,14 +72,22 @@ class NeucbotRunner:
         output_file = self.config.output
 
         print("", file=output_file)
-        print("# Total neutron yield = ", outputs["total_neutron_yield"], " n/decay", file=output_file)
+        print(
+            "# Total neutron yield = ",
+            outputs["total_neutron_yield"],
+            " n/decay",
+            file=output_file,
+        )
 
         cross_sections = outputs["cross_sections"]
         for x in sorted(cross_sections):
             print("\t", x, cross_sections[x], file=output_file)
 
         print(
-            "# Integral of spectrum = ", outputs["spectrum_integral"], " n/decay", file=output_file
+            "# Integral of spectrum = ",
+            outputs["spectrum_integral"],
+            " n/decay",
+            file=output_file,
         )
 
         spectra_totals = outputs["spectra_totals"]

--- a/neucbot/runner.py
+++ b/neucbot/runner.py
@@ -20,7 +20,13 @@ class NeucbotRunner:
         cross_sections = {}
         total_cross_section = 0
 
-        for [energy, intensity] in tqdm(alpha_list.condense(step_size)):
+        condensed_alpha_list = alpha_list.condense(step_size)
+
+        # If this is not being run as part of a web request, show a progress bar
+        if not self.config.json:
+            condensed_alpha_list = tqdm(condensed_alpha_list)
+
+        for [energy, intensity] in condensed_alpha_list:
             stopping_power = material_composition.stopping_power(energy)
 
             for material in material_composition.materials:

--- a/neucbot/runner.py
+++ b/neucbot/runner.py
@@ -43,31 +43,35 @@ class NeucbotRunner:
                 for e in spec.keys():
                     spec_totals[e] = spec_totals.get(e, 0) + prefactors * spec.get(e)
 
-        self.print_outputs(total_cross_section, cross_sections, spec_totals)
-
-        return {
-            "total_cross_section": total_cross_section,
-            "cross_sections": cross_sections,
-            "spectra_totals": spec_totals,
+        outputs = {
+            "total_neutron_yield": utils.format_float(total_cross_section),
+            "cross_sections": {el: utils.format_float(x) for el, x in cross_sections.items()},
+            "spectrum_integral": utils.format_float(
+                utils.Histogram(spec_totals).integrate()
+            ),
+            "spectra_totals": {e: utils.format_float(v) for e, v in spec_totals.items()},
         }
 
-    def print_outputs(self, total_cross_section, cross_sections, spectra_totals):
+        if self.config.json:
+            return outputs
+        else:
+            self.print_outputs(outputs)
+            return outputs
+
+    def print_outputs(self, outputs):
         output_file = self.config.output
 
-        rounded_total = utils.format_float(total_cross_section)
-        rounded_integral = utils.format_float(
-            utils.Histogram(spectra_totals).integrate()
-        )
-
         print("", file=output_file)
-        print("# Total neutron yield = ", rounded_total, " n/decay", file=output_file)
+        print("# Total neutron yield = ", outputs["total_neutron_yield"], " n/decay", file=output_file)
 
+        cross_sections = outputs["cross_sections"]
         for x in sorted(cross_sections):
-            print("\t", x, utils.format_float(cross_sections[x]), file=output_file)
+            print("\t", x, cross_sections[x], file=output_file)
 
         print(
-            "# Integral of spectrum = ", rounded_integral, " n/decay", file=output_file
+            "# Integral of spectrum = ", outputs["spectrum_integral"], " n/decay", file=output_file
         )
 
+        spectra_totals = outputs["spectra_totals"]
         for e in sorted(spectra_totals):
-            print(e, utils.format_float(spectra_totals[e]), file=output_file)
+            print(e, spectra_totals[e], file=output_file)

--- a/neucbot/runner.py
+++ b/neucbot/runner.py
@@ -14,7 +14,6 @@ class NeucbotRunner:
     def run(self, alpha_list, material_composition, step_size=ALPHA_STEP):
         run_talys = self.config.talys
         force_recalc = self.config.force_recalculation
-        print("Running alphas:")
 
         spec_totals = {}
         cross_sections = {}
@@ -24,6 +23,7 @@ class NeucbotRunner:
 
         # If this is not being run as part of a web request, show a progress bar
         if not self.config.json:
+            print("Running alphas:")
             condensed_alpha_list = tqdm(condensed_alpha_list)
 
         for [energy, intensity] in condensed_alpha_list:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -28,12 +28,13 @@ class TestNeucbotRunner(TestCase):
 
         expected = {
             "cross_sections": {
-                "C12": pytest.approx(1.517498e-06),
-                "H1": pytest.approx(9.104992e-06),
-                "O16": pytest.approx(5.690620e-07),
+                "C12": "1.517499e-06",
+                "H1": "9.104992e-06",
+                "O16": "5.690620e-07",
             },
-            "spectra_totals": {1000: pytest.approx(1.119155e22)},
-            "total_cross_section": pytest.approx(1.119155e-05),
+            "spectra_totals": {1000: "1.119155e+22"},
+            "spectrum_integral": "1.119155e+25",
+            "total_neutron_yield": "1.119155e-05",
         }
 
         assert neucbot.run(alpha_list, comp) == expected


### PR DESCRIPTION
This commit adds a new option for neucBOT that will be used in the web interface. It allows for the neucBOT outputs to be returned as a JSON object rather than being printed. The default behavior is still to print values to an output file or stdout.