### PR TITLE
Add preprocessing scripts for TALYS and ENSDF data

### DIFF
--- a/preprocess_ENSDF.py
+++ b/preprocess_ENSDF.py
@@ -1,0 +1,15 @@
+import json
+
+from neucbot import alpha
+
+if __name__ == "__main__":
+    with open("./neucbot/elements.json", "r") as file:
+        isotopesMap = json.load(file)
+
+        for element, isoMap in isotopesMap.items():
+            for mass_number in isoMap:
+                try:
+                    print("Downloading AlphaList file for:", element, mass_number)
+                    alpha.AlphaList(element, mass_number).write()
+                except RuntimeError:
+                    print("No AlphaList file for:", element, mass_number)

--- a/preprocess_talys.py
+++ b/preprocess_talys.py
@@ -1,0 +1,35 @@
+import json
+
+from preprocessing import talys
+
+with open("./neucbot/elements.json", "r") as file:
+    isotopesMap = json.load(file)
+
+
+if __name__ == "__main__":
+    for element, isoMap in isotopesMap.items():
+        preproc = talys.TalysPreprocessor(element)
+
+        # Skip if already preprocessed
+        if preproc.processed_files_exist():
+            print("Already computed for ", element)
+            continue
+
+        # Download complete TALYS data if not present
+        preproc.download_v2_if_not_present()
+        preproc.download_v1_if_not_present()
+
+        # Perform preprocessing
+        for mass_number in isoMap:
+
+            # Skip this element/mass_number if TALYS data is not available for it
+            if not preproc.talys_full_data_exists(mass_number):
+                print("Unable to preprocess TALYS data for:", element, mass_number)
+                continue
+
+            print("Processing TALYS outputs for:", element, mass_number)
+            preproc.process_talys_out(mass_number)
+            preproc.process_talys_nspec(mass_number)
+
+        # Clean up complete TALYS data to free up disk space
+        preproc.clean_isotope_data()

--- a/preprocessing/talys.py
+++ b/preprocessing/talys.py
@@ -1,0 +1,149 @@
+import os
+import re
+import json
+import subprocess
+import shutil
+
+from neucbot.material import NEUTRON_CROSS_SECTION_PATTERN, mb_to_cm2, MeV_to_keV
+from neucbot.talys import ISOTOPES_DIR
+
+TALYS_OUT_JSON_PATH = "./Data/Preprocessed/TalysOut/"
+TALYS_NSPEC_JSON_PATH = "./Data/Preprocessed/TalysNSpec/"
+
+
+class TalysPreprocessor:
+    def __init__(self, element):
+        self.element = element
+
+        # Input Directories
+        self.base_dir = os.path.join(ISOTOPES_DIR, element)
+
+        # Preprocessing Output Directories
+        self.preproc_talys_out_dir = os.path.join(TALYS_OUT_JSON_PATH, self.element)
+        self.preproc_talys_nspec_dir = os.path.join(TALYS_NSPEC_JSON_PATH, self.element)
+        os.makedirs(self.preproc_talys_out_dir, exist_ok=True)
+        os.makedirs(self.preproc_talys_nspec_dir, exist_ok=True)
+
+    # Preprocessing File Output paths
+    def preproc_talys_out_filepath(self, mass_number):
+        return os.path.join(TALYS_OUT_JSON_PATH, self.element, f"{mass_number}.json")
+
+    def preproc_talys_nspec_filepath(self, mass_number):
+        return os.path.join(TALYS_NSPEC_JSON_PATH, self.element, f"{mass_number}.json")
+
+    # TALYS complete data methods
+    def download_v2_if_not_present(self):
+        if not os.path.exists(f"./Data/Isotopes/{self.element}"):
+            print("Downloading TALYS outputs for:", self.element)
+            subprocess.call(
+                f"./Scripts/download_element_v2.sh {self.element}", shell=True
+            )
+        else:
+            print(f"Data already exists for {self.element}")
+
+    def download_v1_if_not_present(self):
+        if not os.path.exists(f"./Data/Isotopes/{self.element}"):
+            print("Downloading TALYS outputs for:", self.element)
+            subprocess.call(
+                f"./Scripts/download_element_v1.sh {self.element}", shell=True
+            )
+        else:
+            print(f"Data already exists for {self.element}")
+
+    def talys_full_data_exists(self, mass_number):
+        talys_full_out_exists = os.path.exists(self.talys_output_dir(mass_number))
+        talys_full_nspec_exists = os.path.exists(self.talys_nspec_dir(mass_number))
+
+        return talys_full_out_exists and talys_full_nspec_exists
+
+    def clean_isotope_data(self):
+        if os.path.exists(self.base_dir):
+            shutil.rmtree(self.base_dir)
+
+    def processed_files_exist(self):
+        talys_out_exists = os.path.exists(self.preproc_talys_out_dir) and os.listdir(
+            self.preproc_talys_out_dir
+        )
+        talys_nspec_exists = os.path.exists(
+            self.preproc_talys_nspec_dir
+        ) and os.listdir(self.preproc_talys_nspec_dir)
+
+        return talys_out_exists and talys_nspec_exists
+
+    def talys_output_dir(self, mass_number):
+        return os.path.join(self.base_dir, f"{self.element}{mass_number}", "TalysOut")
+
+    def talys_nspec_dir(self, mass_number):
+        return os.path.join(self.base_dir, f"{self.element}{mass_number}", "Nspectra")
+
+    # Preprocessing methods
+    def process_talys_nspec(self, mass_number):
+        spectra = {}
+
+        talys_nspec_dir = self.talys_nspec_dir(mass_number)
+        print(talys_nspec_dir)
+
+        if not os.path.exists(talys_nspec_dir):
+            UNPROCESSED_NSPEC_ELEMENTS.append(self.element + str(mass_number))
+            return
+
+        with os.scandir(talys_nspec_dir) as files:
+            for file in files:
+                if file.is_file() and file.name.startswith("nspec"):
+                    rounded_energy = float(
+                        file.name.removeprefix("nspec").removesuffix(".tot")
+                    )
+
+                    energy_spec = {}
+
+                    file_path = os.path.join(talys_nspec_dir, file.name)
+
+                    with open(file_path, "r") as output_file:
+                        for spec in [line.split() for line in output_file.readlines()]:
+                            if spec == [] or spec[0] == "EMPTY":
+                                break
+                            elif spec[0][0] == "#":
+                                continue
+
+                            energy = int(float(spec[0]) * MeV_to_keV)
+                            sigma = float(spec[1]) * mb_to_cm2 / MeV_to_keV
+
+                            energy_spec[energy] = sigma
+
+                    spectra[rounded_energy] = energy_spec
+
+        with open(self.preproc_talys_nspec_filepath(mass_number), "w") as out_file:
+            json.dump(spectra, out_file, sort_keys=True, indent=2)
+
+    def process_talys_out(self, mass_number):
+        cross_sections = {}
+
+        talys_output_dir = self.talys_output_dir(mass_number)
+
+        if not os.path.exists(talys_output_dir):
+            UNPROCESSED_NSPEC_ELEMENTS.append(self.element + str(mass_number))
+            return
+
+        with os.scandir(talys_output_dir) as files:
+            for file in files:
+                if file.is_file() and file.name.startswith("outputE"):
+                    rounded_energy = file.name.removeprefix("outputE")
+
+                    file_path = os.path.join(talys_output_dir, file.name)
+
+                    with open(file_path, "r") as output_file:
+                        file_text = output_file.read()
+
+                    if cross_section_match := re.search(
+                        NEUTRON_CROSS_SECTION_PATTERN, file_text
+                    ):
+                        cross_section = float(
+                            cross_section_match.group("cross_section")
+                        )
+
+                        cross_sections[rounded_energy] = cross_section * mb_to_cm2
+                    else:
+                        cross_sections[rounded_energy] = 0
+
+        with open(self.preproc_talys_out_filepath(mass_number), "w") as out_file:
+            json.dump(cross_sections, out_file, sort_keys=True, indent=2)


### PR DESCRIPTION
## Changes

By preprocessing these files and storing them as plain JSON files, neucBOT execution can be sped up considerably. While changes to neucBOT to allow for the use of preprocessed data (via a configuration option) will be made in a future PR, local testing has improved performance considerably (more below).

These improved times will allow for a better user experience in the web UI (and also the CLI, if users decide to use preprocessed data).

The one caveat is that, currently, using preprocessed data CANNOT be used with the `--talys` or `--force-recalculation` flags. This mutual exclusivity will be baked into the updated Config class to unsure that one or the other is set (again, this will be in a future PR).

## Performance Improvements

### Data Storage

By preprocessing data, this script condenses the relevant TALYS data _for all elements together_ down to ~182MB, which is comparable to the size of raw TALYS data for a single element (e.g. raw TALYS data for oxygen is ~190MB).

Condensing this data will make the web interface processes less prone to running out of disk space. Storing all raw TALYS data for all elements on a single machine would be expensive, and loading them on an as needed bases without regular pruning would 1) cause some requests to take longer if the necessary elements weren't present on disk and 2) eat up more disk space until none is left, causing subsequent requests to fail.

The 182MB for all data will be easy to fit in memory for faster calculations.

## Speed

While this branch does not update the neucBOT code to use this preprocessed data, I've done some testing on a local branch and it speeds up the calculations considerably from **6-8 seconds per calculation down to 1-3 second per calculation**.

Below is an example calculation (which I've profiled with -cProfile) with **full TALYS data**:
```bash
➜ python3 -m cProfile ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Rn220Alphas.dat -d v2 --json
         2068161 function calls (2041145 primitive calls) in 7.221 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    296/1    0.007    0.000    7.221    7.221 {built-in method builtins.exec}
        1    0.000    0.000    7.221    7.221 neucbot.py:1(<module>)
```

And here is an example calculation with **preprocessed TALYS data**:
```bash
➜ python3 -m cProfile ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Rn220Alphas.dat -d v2 --json
         3192295 function calls (2789145 primitive calls) in 2.728 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    296/1    0.011    0.000    2.728    2.728 {built-in method builtins.exec}
        1    0.015    0.015    2.728    2.728 neucbot.py:1(<module>)
```

Additionally, this data can be cached in memory for the neucBOT web client for even faster retrievals and calculations.