### PR TITLE
Make data source configurable

### DIFF
--- a/neucbot.py
+++ b/neucbot.py
@@ -33,8 +33,8 @@ def main():
         if args.print_alphas_only:
             return
 
-    if args.download:
-        material_composition.download_data(args.download)
+    # Download checks will only download data if it is missing
+    material_composition.download_data(args.download)
 
     runner.run(alpha_list, material_composition, args.step_size)
 

--- a/neucbot.py
+++ b/neucbot.py
@@ -20,7 +20,9 @@ def main():
 
     alpha_list.load_or_fetch()
 
-    material_composition = material.Composition.from_file(args.material)
+    material_composition = material.Composition.from_file(
+        args.material, cfg.data_source_class
+    )
 
     if args.print_alphas or args.print_alphas_only:
         print("Alpha List: ")

--- a/neucbot/argparser.py
+++ b/neucbot/argparser.py
@@ -25,7 +25,8 @@ argparser.add_argument(
 # 1. Alpha step size
 # 2. Run talys during calculations
 # 3. Force recalculation for talys
-# 4. Download missing TALYS data
+# 4. Download missing data
+# 5. Data source to use during calculations
 ####################
 argparser.add_argument(
     "-s",
@@ -53,6 +54,13 @@ argparser.add_argument(
     "--download",
     choices=["v1", "v2"],
     help="Download isotopic data for isotopes missing from database (options: %(choices)s)",
+)
+
+argparser.add_argument(
+    "--data-source",
+    choices=["talys-raw", "talys-slim"],
+    default="talys-slim",
+    help="Dataset used during neucbot calculations (options: %(choices)s)",
 )
 
 ###########################

--- a/neucbot/config.py
+++ b/neucbot/config.py
@@ -1,13 +1,23 @@
 import sys
 import shutil
 
+from neucbot.data.raw_talys import RawTalysDataSource as TalysRaw
+from neucbot.data.slim_talys import TalysSlimDataSource as TalysSlim
+
+DATA_SOURCE_REGISTRY = {
+    "talys-raw": TalysRaw,
+    "talys-slim": TalysSlim,
+}
+
 
 class Config:
     def __init__(self, args):
         self.talys = args.get("talys")
         self.download = args.get("download")
         self.force_recalculation = args.get("force_recalculation")
-        self.data_source = args.get("data_source")
+        self.data_source_class = DATA_SOURCE_REGISTRY.get(
+            args.get("data_source", "talys-slim")
+        )
         self.output = (
             open(args.get("output"), "w") if args.get("output") else sys.stdout
         )
@@ -18,12 +28,12 @@ class Config:
         if not (self.talys or self.force_recalculation):
             return
 
-        # Raise a RuntimeError if attempting to use data_source = slim with
+        # Raise a RuntimeError if attempting to use data_source = talys-slim with
         # either --talys or --force-recalculation. Opting to use preprocessed
         # data does not allow for TALYS calculations
-        if self.data_source == "slim":
+        if self.data_source_class == TalysSlim:
             raise RuntimeError(
-                "Attempting to run TALYS while using preprocessed data. Please rerun without --talys or --force-recalculation."
+                "Attempting to run TALYS calculations while using preprocessed data. Please rerun without --talys or --force-recalculation."
             )
 
         # If TALYS is being run, verify that the talys command is present

--- a/neucbot/data/data_source.py
+++ b/neucbot/data/data_source.py
@@ -17,7 +17,7 @@ class NeucbotDataSource(ABC):
         pass
 
     @abstractmethod
-    def download_data(self):
+    def download_data(self, version):
         pass
 
     @abstractmethod

--- a/neucbot/data/slim_talys.py
+++ b/neucbot/data/slim_talys.py
@@ -32,7 +32,7 @@ class TalysSlimDataSource(NeucbotDataSource):
         spectra = self.talys_nspec.get(rounded_alpha_energy, {})
         return utils.Histogram(spectra)
 
-    def download_data(self):
+    def download_data(self, version=None):
         if os.path.exists(self.base_dir) and os.listdir(self.base_dir):
             return
 

--- a/neucbot/material.py
+++ b/neucbot/material.py
@@ -7,19 +7,16 @@ from bisect import bisect
 from neucbot import elements
 from neucbot import utils
 
-from neucbot.data.raw_talys import RawTalysDataSource as TalysRaw
-from neucbot.data.slim_talys import TalysSlimDataSource as TalysSlim
-
 N_A = 6.0221409e23
 
 
 class Isotope:
     # self.fraction should be a number between 0 and 1
-    def __init__(self, element, mass_number, fraction):
+    def __init__(self, element, mass_number, fraction, data_source_class):
         self.element = element
         self.mass_number = int(mass_number)
         self.fraction = float(fraction)
-        self.data_source = TalysRaw(self.element.symbol, self.mass_number)
+        self.data_source = data_source_class(element.symbol, mass_number)
 
     def material_term(self):
         return (N_A * self.fraction) / self.mass_number
@@ -44,8 +41,8 @@ class Isotope:
         rounded_alpha_energy = int(100 * alpha_energy) / 100.0
         return self.data_source.cross_section(rounded_alpha_energy)
 
-    def download_data(self):
-        self.data_source.download_data()
+    def download_data(self, version=None):
+        self.data_source.download_data(version)
 
 
 class StoppingPowerList:
@@ -95,10 +92,10 @@ class StoppingPowerList:
 
 class Composition:
     @classmethod
-    def from_file(cls, file_path):
+    def from_file(cls, file_path, data_source_class):
         file = open(file_path)
 
-        composition = cls()
+        composition = cls(data_source_class)
 
         for material in [
             line.split() for line in file.readlines() if not line.startswith("#")
@@ -120,8 +117,8 @@ class Composition:
         return composition
 
     @classmethod
-    def from_json(cls, request_json):
-        composition = cls()
+    def from_json(cls, request_json, data_source_class):
+        composition = cls(data_source_class)
 
         for material_element in request_json["elements"]:
             composition.add(material_element)
@@ -131,7 +128,8 @@ class Composition:
 
         return composition
 
-    def __init__(self):
+    def __init__(self, data_source_class):
+        self.data_source_class = data_source_class
         self.materials = []
         self.fractions = {}
         self.stopping_powers = {}
@@ -176,6 +174,7 @@ class Composition:
                         element,
                         isotope,
                         fraction * element.abundance(isotope) / 100.0,
+                        self.data_source_class,
                     )
                 )
 
@@ -183,11 +182,7 @@ class Composition:
         # use the fraction provided
         else:
             self.materials.append(
-                Isotope(
-                    element,
-                    mass_number,
-                    fraction / 100.0,
-                )
+                Isotope(element, mass_number, fraction / 100.0, self.data_source_class)
             )
 
     # Expects an alpha energy in units of MeV
@@ -201,6 +196,6 @@ class Composition:
 
         return total_stopping_power
 
-    def download_data(self, version):
+    def download_data(self, version=None):
         for material in self.materials:
-            material.download_data()
+            material.download_data(version)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,22 @@
+class MockDataSource:
+    def __init__(self, element, mass_number):
+        self.element = element
+        self.mass_number = mass_number
+
+    def allows_talys_calculation(self):
+        return False
+
+    def cross_section(self, rounded_alpha_energy):
+        return 0
+
+    def nspectra(self, rounded_alpha_energy):
+        return {}
+
+    def download_data(self, version):
+        return
+
+    def run_talys(self):
+        return
+
+    def run_talys_with_retries(self):
+        return

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -11,7 +11,7 @@ echo "Materials/Acrylic.dat"
 echo "Chains/Th232Chain.dat"
 echo
 
-python3 ./neucbot.py -m Materials/Acrylic.dat -c Chains/Th232Chain.dat -d v2 -o tmp-acrylic-th232-chain.txt
+python3 ./neucbot.py -m Materials/Acrylic.dat -c Chains/Th232Chain.dat -o tmp-acrylic-th232-chain.txt
 diff tmp-acrylic-th232-chain.txt tests/integration_tests/acrylic-th232-chain.txt
 
 # If the previous diff command generated any differences, the exit code will be 1
@@ -41,7 +41,7 @@ echo "Materials/Acrylic.dat"
 echo "AlphaLists/Rn220Alphas.dat"
 echo
 
-python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Rn220Alphas.dat -d v2 -o tmp-acrylic-rn220-alphalist.txt
+python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Rn220Alphas.dat -o tmp-acrylic-rn220-alphalist.txt
 diff tmp-acrylic-rn220-alphalist.txt tests/integration_tests/acrylic-rn220-alphalist.txt
 
 if [ $? -eq 1 ]; then
@@ -69,7 +69,36 @@ echo "Materials/Acrylic.dat"
 echo "AlphaLists/Bi212Alphas.dat"
 echo
 
-python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt
+python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -o tmp-acrylic-bi212-alphalist.txt
+diff tmp-acrylic-bi212-alphalist.txt tests/integration_tests/acrylic-bi212-alphalist.txt
+
+if [ $? -eq 1 ]; then
+  echo
+  echo "Test failed" >&2
+  echo
+  rm tmp-acrylic-bi212-alphalist.txt
+
+  exit 1
+else
+  echo
+  echo "Test passed"
+  echo
+  rm tmp-acrylic-bi212-alphalist.txt
+fi
+
+##############################
+# Bi212 AlphaList - Raw Data #
+##############################
+
+echo
+echo "Running test with raw data..."
+echo "-----------------------------"
+echo "Materials/Acrylic.dat"
+echo "AlphaLists/Bi212Alphas.dat"
+echo "DATA SOURCE: talys-raw"
+echo
+
+python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt --data-source talys-raw
 diff tmp-acrylic-bi212-alphalist.txt tests/integration_tests/acrylic-bi212-alphalist.txt
 
 if [ $? -eq 1 ]; then
@@ -95,6 +124,7 @@ fi
 # echo "--------------------------"
 # echo "Materials/Acrylic.dat"
 # echo "AlphaLists/Bi212Alphas.dat"
+# echo "DATA SOURCE: talys-raw"
 # echo
 
 # echo "Removing subset of TALYS files..."
@@ -102,13 +132,13 @@ fi
 # rm Data/Isotopes/C/C12/NSpectra/nspec000.0*
 
 # echo "Running neucbot.py with -t enabled..."
-# python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2  -t
+# python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2  -t --data-source talys-raw
 
 # # Since ./neucbot.py prints TALYS information when it is enabled, the output file won't be exactly the same.
 # # The run above downloads the missing files from TALYS and this subsequent run
 # # verifies the output.
 # echo "Running neucbot.py to verify successful TALYS download..."
-# python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt
+# python3 ./neucbot.py -m Materials/Acrylic.dat -l AlphaLists/Bi212Alphas.dat -d v2 -o tmp-acrylic-bi212-alphalist.txt --data-source talys-raw
 # diff tmp-acrylic-bi212-alphalist.txt tests/integration_tests/acrylic-bi212-alphalist.txt
 
 # if [ $? -eq 1 ]; then

--- a/tests/test_alpha.py
+++ b/tests/test_alpha.py
@@ -289,7 +289,6 @@ class TestChainAlphaList(TestCase):
         )
 
     def test_condense(self):
-        pass
         chain_list = ChainAlphaList.from_filepath("Chains/Th232Chain.dat")
         chain_list.load_or_fetch()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,38 +8,53 @@ from neucbot import config
 
 
 class TestConfig(TestCase):
+    def setUp(self):
+        self.raw_config = config.Config({"data_source": "talys-raw"})
+        self.slim_config = config.Config({"data_source": "talys-slim"})
+
     @patch("shutil.which", return_value=True)
     def test_validate_no_talys_configured(self, mock_which):
-        config.Config({"talys": False}).validate()
+        self.raw_config.validate()
         mock_which.assert_has_calls([])
 
     @patch("shutil.which", return_value=True)
     def test_validate_talys_configured_command_present(self, mock_which):
-        config.Config({"talys": True}).validate()
+        cfg = self.raw_config
+        cfg.talys = True
+        cfg.validate()
+
         mock_which.assert_has_calls([call("talys")])
 
     @patch("shutil.which", return_value=True)
-    def test_validate_talys_configured_command_present_force_recalc_passed(
-        self, mock_which
-    ):
-        config.Config({"force_recalculation": True}).validate()
+    def test_validate_force_recalc_with_talys_present(self, mock_which):
+        cfg = self.raw_config
+        cfg.force_recalculation = True
+        cfg.validate()
+
         mock_which.assert_has_calls([call("talys")])
 
     @patch("shutil.which", return_value=False)
-    def test_validate_talys_configured_command_not_present(self, mock_which):
+    def test_validate_talys_command_not_present(self, mock_which):
         with self.assertRaisesRegex(RuntimeError, r"talys command is not available"):
-            config.Config({"talys": True}).validate()
+            cfg = self.raw_config
+            cfg.talys = True
+            cfg.validate()
+
             mock_which.assert_has_calls([call("talys")])
 
     @patch("shutil.which", return_value=True)
     def test_validate_slim_data_no_talys(self, mock_which):
-        config.Config({"talys": False, "data_source": "slim"}).validate()
+        self.slim_config.validate()
+
         mock_which.assert_has_calls([])
 
     @patch("shutil.which", return_value=True)
     def test_validate_slim_data_with_talys_configured(self, mock_which):
         with self.assertRaisesRegex(
-            RuntimeError, r"run TALYS while using preprocessed data"
+            RuntimeError, r"run TALYS calculations while using preprocessed data"
         ):
-            config.Config({"talys": True, "data_source": "slim"}).validate()
+            cfg = self.slim_config
+            cfg.talys = True
+            cfg.validate()
+
             mock_which.assert_has_calls([])

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -5,11 +5,13 @@ from unittest.mock import call, mock_open, patch
 
 from neucbot import elements, material
 
+from tests.helpers import MockDataSource
+
 
 class TestIsotope(TestCase):
     def setUp(self):
         carbon = elements.Element("C")
-        self.isotope = material.Isotope(carbon, 13, 1.0)
+        self.isotope = material.Isotope(carbon, 13, 1.0, MockDataSource)
 
     def test_material_term(self):
         assert self.isotope.material_term() == material.N_A * 1.0 / 13
@@ -17,18 +19,13 @@ class TestIsotope(TestCase):
     def test_name(self):
         assert self.isotope.name() == "C13"
 
-    @patch(
-        "neucbot.data.raw_talys.RawTalysDataSource.allows_talys_calculation",
-        return_value=False,
-    )
+    @patch.object(MockDataSource, "allows_talys_calculation", return_value=False)
     def test_differential_n_spec_no_talys(self, mock_talys_allowed):
-        pass
+        self.isotope.differential_n_spec(1.05)
+        mock_talys_allowed.assert_has_calls([call()])
 
-    @patch("neucbot.data.raw_talys.RawTalysDataSource.run_talys")
-    @patch(
-        "neucbot.data.raw_talys.RawTalysDataSource.allows_talys_calculation",
-        return_value=True,
-    )
+    @patch.object(MockDataSource, "run_talys")
+    @patch.object(MockDataSource, "allows_talys_calculation", return_value=True)
     def test_differential_n_spec_force_recalculation(
         self, mock_talys_allowed, mock_talys
     ):
@@ -36,11 +33,8 @@ class TestIsotope(TestCase):
         mock_talys_allowed.assert_has_calls([call()])
         mock_talys.assert_has_calls([call(1.05)])
 
-    @patch("neucbot.data.raw_talys.RawTalysDataSource.run_talys_with_retries")
-    @patch(
-        "neucbot.data.raw_talys.RawTalysDataSource.allows_talys_calculation",
-        return_value=True,
-    )
+    @patch.object(MockDataSource, "run_talys_with_retries")
+    @patch.object(MockDataSource, "allows_talys_calculation", return_value=True)
     def test_differential_n_spec_talys_allowed_and_run(
         self, mock_talys_allowed, mock_talys
     ):
@@ -48,10 +42,7 @@ class TestIsotope(TestCase):
         mock_talys_allowed.assert_has_calls([call()])
         mock_talys.assert_has_calls([call(1.05)])
 
-    @patch(
-        "neucbot.data.raw_talys.RawTalysDataSource.cross_section",
-        return_value=1.51335e-28,
-    )
+    @patch.object(MockDataSource, "cross_section", return_value=1.51335e-28)
     def test_cross_section(self, mock_cross_section):
         assert self.isotope.cross_section(1.05000002) == 1.51335e-28
         mock_cross_section.assert_has_calls([call(1.05)])
@@ -59,7 +50,9 @@ class TestIsotope(TestCase):
 
 class TestComposition(TestCase):
     def test_from_file_isotopes_specified(self):
-        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
+        comp = material.Composition.from_file(
+            "./tests/test_material/WithIsotopes.dat", MockDataSource
+        )
 
         assert len(comp.materials) == 3
         assert comp.fractions.get("C") == pytest.approx(0.5)
@@ -67,7 +60,9 @@ class TestComposition(TestCase):
         assert comp.fractions.get("O") == pytest.approx(0.25)
 
     def test_from_file_no_isotopes_specified(self):
-        comp = material.Composition.from_file("./tests/test_material/NoIsotopes.dat")
+        comp = material.Composition.from_file(
+            "./tests/test_material/NoIsotopes.dat", MockDataSource
+        )
 
         assert len(comp.materials) == 7
         assert comp.fractions.get("C") == pytest.approx(0.5)
@@ -83,7 +78,7 @@ class TestComposition(TestCase):
             ]
         }
 
-        comp = material.Composition.from_json(request_json)
+        comp = material.Composition.from_json(request_json, MockDataSource)
 
         assert len(comp.materials) == 3
         assert comp.fractions.get("C") == pytest.approx(0.33)
@@ -99,7 +94,7 @@ class TestComposition(TestCase):
             ]
         }
 
-        comp = material.Composition.from_json(request_json)
+        comp = material.Composition.from_json(request_json, MockDataSource)
 
         assert len(comp.materials) == 7
         assert comp.fractions.get("C") == pytest.approx(0.33)
@@ -107,7 +102,7 @@ class TestComposition(TestCase):
         assert comp.fractions.get("O") == pytest.approx(0.34)
 
     def test_normalize(self):
-        comp = material.Composition()
+        comp = material.Composition(MockDataSource)
 
         comp.add({"element": "C", "mass_number": "12", "fraction": 0.4})
         comp.add({"element": "H", "mass_number": "1", "fraction": 0.2})
@@ -120,7 +115,9 @@ class TestComposition(TestCase):
         assert comp.fractions.get("O") == pytest.approx(0.25)
 
     def test_stopping_power_single_element_material(self):
-        comp = material.Composition.from_file("./tests/test_material/CarbonOnly.dat")
+        comp = material.Composition.from_file(
+            "./tests/test_material/CarbonOnly.dat", MockDataSource
+        )
         assert len(comp.materials) == 1
         assert comp.fractions == {"C": 1.0}
 
@@ -129,7 +126,9 @@ class TestComposition(TestCase):
         assert comp.stopping_power(11.0) == 486.0835
 
     def test_stopping_power_multi_element_material(self):
-        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
+        comp = material.Composition.from_file(
+            "./tests/test_material/WithIsotopes.dat", MockDataSource
+        )
 
         assert len(comp.materials) == 3
         assert comp.fractions.get("C") == pytest.approx(0.5)
@@ -141,48 +140,16 @@ class TestComposition(TestCase):
         # 25% stopping power of O = 0.25 * 462.8758
         assert comp.stopping_power(11.0) == 701.5617
 
-    @patch("subprocess.call")
-    @patch("os.listdir", return_value=["data"])
-    def test_download_data_all_data_present(self, mocked_listdir, mocked_call):
-        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
-
-        comp.download_data("v2")
-
-        mocked_listdir.assert_has_calls(
-            [
-                call("./Data/Isotopes/C/C12/TalysOut"),
-                call("./Data/Isotopes/C/C12/NSpectra"),
-                call("./Data/Isotopes/O/O16/TalysOut"),
-                call("./Data/Isotopes/O/O16/NSpectra"),
-                call("./Data/Isotopes/H/H1/TalysOut"),
-                call("./Data/Isotopes/H/H1/NSpectra"),
-            ]
+    @patch.object(MockDataSource, "download_data")
+    def test_download_data(self, mocked_download_data):
+        comp = material.Composition.from_file(
+            "./tests/test_material/WithIsotopes.dat", MockDataSource
         )
 
-        mocked_call.assert_has_calls([])
+        comp.download_data()
 
-    @patch("subprocess.call")
-    @patch("os.listdir", return_value=[])
-    def test_download_data_missing_data(self, mocked_listdir, mocked_call):
-        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
-
-        comp.download_data("v2")
-
-        mocked_listdir.assert_has_calls(
-            [
-                call("./Data/Isotopes/C/C12/TalysOut"),
-                call("./Data/Isotopes/O/O16/TalysOut"),
-                call("./Data/Isotopes/H/H1/TalysOut"),
-            ]
-        )
-
-        mocked_call.assert_has_calls(
-            [
-                call("./Scripts/download_element_v2.sh C", shell=True),
-                call("./Scripts/download_element_v2.sh O", shell=True),
-                call("./Scripts/download_element_v2.sh H", shell=True),
-            ]
-        )
+        # Each #download_data on the isotopes is called, for a total of 3
+        mocked_download_data.assert_has_calls([call(None), call(None), call(None)])
 
 
 class TestStoppingPowerList(TestCase):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,6 +7,8 @@ import numpy
 
 from neucbot import alpha, config, material, runner, utils
 
+from tests.helpers import MockDataSource
+
 
 class TestNeucbotRunner(TestCase):
     @patch.object(material.Isotope, "cross_section", return_value=1e-27)
@@ -24,7 +26,9 @@ class TestNeucbotRunner(TestCase):
         alpha_list = alpha.AlphaList.from_filepath("AlphaLists/Bi212Alphas.dat")
         alpha_list.load_or_fetch()
 
-        comp = material.Composition.from_file("./tests/test_material/WithIsotopes.dat")
+        comp = material.Composition.from_file(
+            "./tests/test_material/WithIsotopes.dat", MockDataSource
+        )
 
         expected = {
             "cross_sections": {


### PR DESCRIPTION
This PR adds a `DATA_SOURCE_REGISTRY` to the neucbot/config.py module and makes the data source configurable. Currently, there are two options:

- TalysRaw: Run neucbot calculations with the complete TALYS data
- TalysSlim: Run neucbot calculations with the slim (preprocessed) data

Additionally, this makes the TalysSlim data source the **_default_** data source, meaning users who run calculations on the latest commit should see significant performance improvements.