### PR TITLE
Switch talys_slim to neucbot-datasets org

### DIFF
--- a/neucbot/data/slim_talys.py
+++ b/neucbot/data/slim_talys.py
@@ -11,7 +11,7 @@ from neucbot import utils
 from neucbot.data.data_source import NeucbotDataSource
 
 TALYS_SLIM_VERSION = "0.0.1"
-TALYS_SLIM_URL = f"https://github.com/mpiercy827/talys_slim/archive/refs/tags/v{TALYS_SLIM_VERSION}.tar.gz"
+TALYS_SLIM_URL = f"https://github.com/neucbot-datasets/talys_slim/archive/refs/tags/v{TALYS_SLIM_VERSION}.tar.gz"
 TALYS_SLIM_TAR_PATH = "talys_slim.tar.gz"
 TALYS_SLIM_DESTINATION = "./Data"
 


### PR DESCRIPTION
I'm transferring ownership of the talys_slim repository to neucbot-datasets. I will also be forking the repository to my own Github account to ensure backwards compatibility.